### PR TITLE
Fix pre/post routing.

### DIFF
--- a/classes.d/external
+++ b/classes.d/external
@@ -21,6 +21,9 @@ policy postrouting masquerade
 # If you want to restrict external access further you can add an extra
 # option such as 'ip saddr 10.1.1.0/24' (no quotes) to the above command before
 # the masquerade verdict target
+#
+# Note: this feature requires new versions of linux kernel (>= 5.2)
+# and nftables (>= 0.9.1).
 
 # Advanced Configuration Examples
 

--- a/support/firewall.functions
+++ b/support/firewall.functions
@@ -513,20 +513,20 @@ function load_interface_rules() {
 		done
 		echo "	}" >> "${OF}"
 	fi
-	if [ ${#PREROUTING[@]} -gt 0 ]; then
+	if [ ${#PRE_ROUTE[@]} -gt 0 ]; then
 		HOOK_PREROUTING=1
 		PREROUTING_IFACE+=($if)
 		echo "	chain ${if}_prerouting {" >> "${OF}"
-		for i in "${PREROUTING[@]}"; do
+		for i in "${PRE_ROUTE[@]}"; do
 			echo "		$i" >> "${OF}"
 		done
 		echo "	}" >> "${OF}"
 	fi
-	if [ ${#POSTROUTING[@]} -gt 0 ]; then
+	if [ ${#POST_ROUTE[@]} -gt 0 ]; then
 		HOOK_POSTROUTING=1
 		POSTROUTING_IFACE+=($if)
 		echo "	chain ${if}_postrouting {" >> "${OF}"
-		for i in "${POSTROUTING[@]}"; do
+		for i in "${POST_ROUTE[@]}"; do
 			echo "		$i" >> "${OF}"
 		done
 		echo "	}" >> "${OF}"
@@ -555,9 +555,20 @@ function build_vmap () {
 			exit -1
 	esac
 
+	case $HOOK in
+		prerouting|postrouting)
+			chain_type="nat"
+			default_policy="accept"
+			;;
+		input|output)
+			chain_type="filter"
+			default_policy="drop"
+			;;
+	esac
+
 	if [ "${REG}" -gt 0 ]; then
 		echo "	chain $CHAIN {" >> "${OF}"
-		echo "		type filter hook $HOOK priority 0; policy drop;" >> "${OF}"
+		echo "		type ${chain_type} hook ${HOOK} priority 0; policy ${default_policy};" >> "${OF}"
 
 		if [ "$VMAP_IIF" -eq 1 ]; then
 			echo "		meta $map_iif vmap {" >> "${OF}"


### PR DESCRIPTION
* Use correct variable names for fetching pre/post routing rules.
* Use correct chain type for pre/post routing rules.
* Add note to example rule file that NAT for inet nftables wasn't implemented until linux 5.2 and nftables 0.9.1: https://git.netfilter.org/nftables/commit/?id=fbe27464dee4588d90649274925145421c84b449