### PR TITLE
Refactor s/accept/return/ for forward-in rules.

### DIFF
--- a/support/firewall.functions
+++ b/support/firewall.functions
@@ -247,28 +247,24 @@ function nft(){
 			OUT+=("${rule}")
 			;;
 		forward-in)
-			re="(.*)\<accept\>(.*)"
-			# Replace a non terminator accept with return
-			if [[ "$@" =~ $re ]]; then
-				rule="${BASH_REMATCH[1]} return ${BASH_REMATCH[2]}"
-				rule=$(trim "${rule}")
+			# Replace accept with return so packets get passed on to forward-out
+			if [ "${verdict}" == "accept" ]; then
+				FWD_IN+=("${matches} return")
+			else
+				FWD_IN+=("${rule}")
 			fi
-			FWD_IN+=("${rule}")
 			;;
 		forward-out)
 			FWD_OUT+=("${rule}")
 			;;
 		forward)
-			OLD_RULE="${rule}"
-			re="(.*)\<accept\>(.*)"
-			# Replace a non terminator accept with return
-			if [[ "$@" =~ $re ]]; then
-				rule="${BASH_REMATCH[1]} return ${BASH_REMATCH[2]}"
-				rule=$(trim "${rule}")
+			# Replace accept with return so packets get passed on to forward-out
+			if [ "${verdict}" == "accept" ]; then
+				FWD_IN+=("${matches} return")
+			else
+				FWD_IN+=("${rule}")
 			fi
-			FWD_IN+=("${rule}")
 
-			rule=${OLD_RULE}
 			remap_inout "${rule}"
 			FWD_OUT+=("${rule}")
 			;;


### PR DESCRIPTION
Clean up how forward-in rules are generated.

replaces #11 