### PR TITLE
Fix spelling mistakes.

### DIFF
--- a/classes.d/external
+++ b/classes.d/external
@@ -47,8 +47,8 @@ if_feature autoconf 1            # Enable IPv6 autoconf?
 if_feature rp_filter 1           # Enable Reverse Router Filtering
 if_feature accept_redirects 0    # Accept Redirects
 if_feature accept_source_route 0 # Accept Source Routes
-if_feature bootp_relay 0         # Dont forward bootp requests
-if_feature accept_ra 0           # Accept IPv6 Router Advertisments
+if_feature bootp_relay 0         # Don't forward bootp requests
+if_feature accept_ra 0           # Accept IPv6 Router Advertisements
                                  # (overridden if v6 forwarding is enabled)
 if_feature forwarding 1          # Forward packets arriving on this interface
 if_feature log_martians 0        # Log martians?

--- a/classes.d/host
+++ b/classes.d/host
@@ -6,7 +6,7 @@
 # On a simple host you may choose not to include localhost.if and just use
 # all configuration on the interfaces, but when you have multiple public
 # interfaces which may have some local rules and some shared rules, you
-# can use this for the shared rules, and include them amounst the local rules
+# can use this for the shared rules, and include them amongst the local rules
 # where appropriate. The localhost file should not include termination policy
 # like "policy in accept" or "policy out reject" so that interfaces can put
 # rules after the host policy if it chooses.

--- a/classes.d/internal
+++ b/classes.d/internal
@@ -13,8 +13,8 @@ if_feature autoconf 1            # Enable IPv6 autoconf?
 if_feature rp_filter 1           # Enable Reverse Router Filtering
 if_feature accept_redirects 1    # Accept Redirects
 if_feature accept_source_route 1 # Accept Source Routes
-if_feature bootp_relay 0         # Dont forward bootp requests
-if_feature accept_ra 0           # Accept IPv6 Router Advertisments
+if_feature bootp_relay 0         # Don't forward bootp requests
+if_feature accept_ra 0           # Accept IPv6 Router Advertisements
                                  # (overridden if v6 forwarding is enabled)
 if_feature forwarding 1          # Forward packets arriving on this interface
 if_feature log_martians 0        # Log martians?

--- a/classes.d/loopback
+++ b/classes.d/loopback
@@ -10,8 +10,8 @@ policy forward reject
 if_feature rp_filter 1           # Enable Reverse Router Filtering
 if_feature accept_redirects 0    # Accept Redirects
 if_feature accept_source_route 0 # Accept Source Routes
-if_feature bootp_relay 0         # Dont forward bootp requests
-if_feature accept_ra 0           # Accept IPv6 Router Advertisments
+if_feature bootp_relay 0         # Don't forward bootp requests
+if_feature accept_ra 0           # Accept IPv6 Router Advertisements
                                  # (overridden if v6 forwarding is enabled)
 if_feature forwarding 0          # Forward packets arriving on this interface
 if_feature log_martians 0        # Log martians?

--- a/src/config.in
+++ b/src/config.in
@@ -25,25 +25,25 @@
 logging=none
 
 #
-# Connnection tracking
+# Connection tracking
 #
 # Should bearwall act as a stateful or stateless firewall with packets being
 # forwarded through the firewall.
 #
-# Note: Packets being delt with on the local host (INPUT and OUTPUT) must
+# Note: Packets being dealt with on the local host (INPUT and OUTPUT) must
 # be statefully tracked even in a stateless configuration
 #
 # Values:
 #    - stateful
 #        All packets are processed by conntrack enabling full stateful firewall
-#        features like 'ct' matching on foward rules, dnat, snat and masquerade.
+#        features like 'ct' matching on forward rules, dnat, snat and masquerade.
 #    - local
 #        bearwall inspects the routing table for all local routes on load
 #        and statically enables connection tracking for these routes only. This
-#        means that packets forwared though the machne skip conntrack and
-#        no stateful matches are possible in foward. Stateful firewall features
+#        means that packets forwarded through the machine skip conntrack and
+#        no stateful matches are possible in forward. Stateful firewall features
 #        are only available on in, out, and inout targets.
-#        Note: Does play well with IPv6 privicy adresses and other
+#        Note: Does play well with IPv6 privacy addresses and other
 #        dynamic addresses.
 #    - stateless
 #        Conntrack is disabled for all packets. No stateful firewall features
@@ -58,18 +58,18 @@ conntrack=stateful
 # What should bearwall do when it comes across an interface that it has a
 # firewall definition for, but the interface does not exist on the host.
 #
-# By default bearwall uses a intrface matching mode where nftables matches all
+# By default bearwall uses an interface matching mode where nftables matches all
 # interface names to ifIndex and interfaces are matched by nftable at run time
-# using the inIndex only. This is a much faster way of operating, but resaults
+# using the inIndex only. This is a much faster way of operating, but results
 # in nftable errors on load if the interface does not exist. Bearwall can
 # help deal with this by a few methods
 #
 # Values:
 #    - ifname
-#        Allways use ifname rather ifIndex (Warning SLOW)
+#        Always use ifname rather ifIndex (Warning SLOW)
 #    - lazy
 #        Fallback to ifname if interface does not exist (Warning potentially
-#        slow on high through put routers)
+#        slow on high throughput routers)
 #    - withhold
 #        Don't configure rules for the interface if it does not exist
 #    - error


### PR DESCRIPTION
Fixed spelling mistakes in:

- classes.d/external
- classes.d/host
- classes.d/internal
- classes.d/loopback
- src/config.in