### PR TITLE
Change how bearwall2 starts on boot

### DIFF
--- a/debian/bearwall2.bearwall2-early.service
+++ b/debian/bearwall2.bearwall2-early.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Bearwall2 early boot
+Before=network-pre.target
+Wants=network-pre.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=no
+ExecStart=/usr/sbin/bearwall2
+
+[Install]
+WantedBy=multi-user.target

--- a/debian/bearwall2.bearwall2.service
+++ b/debian/bearwall2.bearwall2.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Bearwall2
-Before=network.target
+After=network-online.target
+Wants=network-online.target
 
 [Service]
 Type=oneshot

--- a/debian/rules
+++ b/debian/rules
@@ -6,6 +6,15 @@
 %:
 	dh $@ --with systemd
 
-
 override_dh_auto_install:
 	dh_auto_install -- DESTDIR=$$(pwd)/debian/bearwall2 BINDIR=/usr/sbin SHARDIR=/usr/share ETCDIR=/etc CACHEDIR=/var/cache
+
+override_dh_systemd_enable:
+	dh_systemd_enable --name=bearwall2
+
+override_dh_installinit:
+	dh_installinit --name=bearwall2
+	dh_installinit --name=bearwall2-early --no-start
+
+override_dh_systemd_start:
+	dh_systemd_start bearwall2.service

--- a/src/config.in
+++ b/src/config.in
@@ -77,8 +77,8 @@ conntrack=stateful
 #    - ignore
 #        Don't detect case (Most likely nftables will fail to load)
 #
-# Default missing=withhold
-missing=withhold
+# Default missing=lazy
+missing=lazy
 
 #
 # Transient interfaces


### PR DESCRIPTION
Change default missing mode to `lazy` and update how bearwall2 is started with systemd:

  1. Load bearwall2 early in the boot process to ensure there is an
     active firewall policy before networking comes up.

  2. Reload bearwall2 after networking comes up to update interface
     references to use ifindex instead of ifname.